### PR TITLE
Google API client respects GCP Emulator env vars

### DIFF
--- a/src/Google/Client.php
+++ b/src/Google/Client.php
@@ -783,8 +783,12 @@ class Google_Client
 
     // call the authorize method
     // this is where most of the grunt work is done
-    $http = $this->authorize();
-
+    // if this is an emulator connection, skip oauth
+    if (getenv("PUBSUB_EMULATOR_HOST") || getenv("DATASTORE_EMULATOR_HOST")) {
+      $http = $this->getHttpClient();
+    } else {
+      $http = $this->authorize();
+    }
     return Google_Http_REST::execute($http, $request, $expectedClass, $this->config['retry']);
   }
 


### PR DESCRIPTION
If the `PUBSUB_EMULATOR_HOST` or `DATASTORE_EMULATOR_HOST` environment variables are set, skip OAUTH (which is not provided by the Google GCP Emulator).